### PR TITLE
Replace `com.sun.mail:javax.mail:1.5.0` with the recommended `com.sun.mail:jakarta.mail:2.0.1`

### DIFF
--- a/coherence/README.md
+++ b/coherence/README.md
@@ -130,7 +130,7 @@ Ensure that the deployment action from Eclipse will target the WebLogic Cluster 
 ## Connect to the Coherence JMX Server using JConsole
 The Coherence Mbean server will be started on the oldest machine of the cluster, so we need to find it and connect to it. We can connect using JConsole. [JConsole](https://en.wikipedia.org/wiki/JConsole) is a GUI tool that can monitor remote JVMs, and it comes for free with the JDK.
 * Go to `<admin server DNS name>:7001/console`.
-* Sign in with username=`weblogic`, password=`Secret123456`.
+* Sign in with username `weblogic` and password that was specified in section [Create the WebLogic Cluster on Azure](#create-the-weblogic-cluster-on-azure).
 * Click `Diagonostics` in "Domain Structure" window, and go to `Log Files`.
 * Look for `ServerLog` of server `msp1`, select and click the `View` button.
 * Click `Customize this table` and change `Time Interval` to `All` and `Number of rows displayed per page` to `5000`, click `Apply`.
@@ -154,7 +154,7 @@ The Coherence Mbean server will be started on the oldest machine of the cluster,
 ```
 service:jmx:t3://<Oldest Machine IP>:8501/jndi/weblogic.management.mbeanservers.runtime
 ```
-* Fill in username=`weblogic`, password=`Secret123456`, click Connect. If a window pops up and says 'Secure connection failed. Retry insecurely?', click `Insecure connection`.
+* Fill in username as `weblogic`, password as what was specified in section [Create the WebLogic Cluster on Azure](#create-the-weblogic-cluster-on-azure), click Connect. If a window pops up and says 'Secure connection failed. Retry insecurely?', click `Insecure connection`.
 * After the connection is established, verify it by checking there is a green connection icon on the top right.
 
 ## Test the cache

--- a/coherence/weblogic-cafe/pom.xml
+++ b/coherence/weblogic-cafe/pom.xml
@@ -20,7 +20,18 @@
 			<artifactId>javaee-api</artifactId>
 			<version>${javaee.api.version}</version>
 			<scope>provided</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.sun.mail</groupId>
+                    <artifactId>javax.mail</artifactId>
+                </exclusion>
+            </exclusions>
 		</dependency>
+        <dependency>
+            <groupId>com.sun.mail</groupId>
+            <artifactId>jakarta.mail</artifactId>
+            <version>2.0.1</version>
+        </dependency>
 	</dependencies>
 	<build>
 		<finalName>${project.artifactId}</finalName>

--- a/javaee/weblogic-cafe/pom.xml
+++ b/javaee/weblogic-cafe/pom.xml
@@ -20,7 +20,18 @@
 			<artifactId>javaee-api</artifactId>
 			<version>${javaee.api.version}</version>
 			<scope>provided</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.sun.mail</groupId>
+                    <artifactId>javax.mail</artifactId>
+                </exclusion>
+            </exclusions>
 		</dependency>
+        <dependency>
+            <groupId>com.sun.mail</groupId>
+            <artifactId>jakarta.mail</artifactId>
+            <version>2.0.1</version>
+        </dependency>
 	</dependencies>
 	<build>
 		<finalName>${project.artifactId}</finalName>


### PR DESCRIPTION
There're two alerts from https://mseng.visualstudio.com/VSJava/_componentGovernance/726?_a=alerts&typeId=116664&alerts-view-option=active:
![image](https://user-images.githubusercontent.com/10357495/165218301-f63c21da-fed6-4d37-a67d-7e0d01be5847.png)

Regarding to `javax:javaee-api:7.0`, I've provided the license info, see [this PR](https://github.com/clearlydefined/curated-data/pull/19314).

Regarding to `com.sun.mail:javax.mail:1.5.0`, it's one of compile dependencies for [javax/javaee-api/7.0](https://mvnrepository.com/artifact/javax/javaee-api/7.0). However, [com.sun.mail:javax.mail](https://mvnrepository.com/artifact/com.sun.mail/javax.mail) was moved to [com.sun.mail:jakarta.mail](https://mvnrepository.com/artifact/com.sun.mail/jakarta.mail). What's more, vulnerability [CVE-2020-15250](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-15250) is found from its dependencies. 

So this PR is to update `com.sun.mail:javax.mail:1.5.0` to `com.sun.mail:jakarta.mail:2.0.1` as recommended in [javax/javaee-api/7.0](https://mvnrepository.com/artifact/javax/javaee-api/7.0):
![image](https://user-images.githubusercontent.com/10357495/165214556-ebe42e32-7315-468a-9627-733fb11dd3da.png)

The another commit appended is to fix issue detected by credential scan pipeline, see [this report](https://dev.azure.com/mseng/VSJava/_build/results?buildId=17186296&view=logs&j=275f1d19-1bd8-5591-b06b-07d489ea915a&t=a480b586-6353-51d9-5327-ea5fc4b13e95&l=12).

Once it's merged, I'll provide the license info for `com.sun.mail:jakarta.mail:2.0.1`, to fix the alert finally.

Signed-off-by: Jianguo Ma <jiangma@microsoft.com>